### PR TITLE
Use GitHub Actions instead of Travis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install cmake
+
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          make
+          make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: cpp
-os: linux
-before_install:
- - sudo apt-get update
- - sudo apt-get install cmake
-script: mkdir build && cd build && cmake .. && make


### PR DESCRIPTION
Run build and tests with GitHub Actions rather than Travis, which we are trying to move away from in our org. 